### PR TITLE
V5.0.0 provider changes

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,22 @@ output "hosted_zone_id" {
 }
 
 output "rds_id" {
+  /*
+     Deprecated:
+     Since aws provider v5.0.0 `aws_db_instance.id` returns resource id instead of instance id.
+     Consider to use `rds_identifier` or `rds_arn` instead.
+     For the details see https://github.com/hashicorp/terraform-provider-aws/pull/31232.
+   */
+  description = "RDS Resource ID (for aws provider >= v5.0.0) or instance id (for aws provider < v5.0.0)."
+  value       = local.resource_id
+}
+
+output "rds_arn" {
+  description = "The RDS ARN"
+  value       = local.arn
+}
+
+output "rds_identifier" {
   description = "The RDS instance ID"
-  value       = local.rds_id
+  value       = local.identifier
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,6 +35,11 @@ output "rds_id" {
   value       = local.resource_id
 }
 
+output "rds_resource_id" {
+  description = "RDS Resource ID"
+  value       = local.resource_id
+}
+
 output "rds_arn" {
   description = "The RDS ARN"
   value       = local.arn

--- a/variables.tf
+++ b/variables.tf
@@ -153,7 +153,7 @@ locals {
   tags = merge({
     Name          = var.name,
     Module        = "RDS MySQL"
-    ModuleVersion = "v0.5.0"
+    ModuleVersion = "v0.5.1"
     ModuleSource  = "https://github.com/jetbrains-infra/terraform-aws-rds-mysql"
   }, var.tags)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -137,10 +137,12 @@ locals {
   vpc_id                              = data.aws_subnet.default.vpc_id
   address                             = local.parameter_group_name == "" ? join("", aws_db_instance.default.*.address) : join("", aws_db_instance.parameterized.*.address)
   hosted_zone_id                      = local.parameter_group_name == "" ? join("", aws_db_instance.default.*.hosted_zone_id) : join("", aws_db_instance.parameterized.*.hosted_zone_id)
-  rds_id                              = local.parameter_group_name == "" ? join("", aws_db_instance.default.*.id) : join("", aws_db_instance.parameterized.*.id)
+  resource_id                         = local.parameter_group_name == "" ? join("", aws_db_instance.default.*.id) : join("", aws_db_instance.parameterized.*.id)
+  identifier                          = local.parameter_group_name == "" ? join("", aws_db_instance.default.*.identifier) : join("", aws_db_instance.parameterized.*.identifier)
+  arn                                 = local.parameter_group_name == "" ? join("", aws_db_instance.default.*.arn) : join("", aws_db_instance.parameterized.*.arn)
   storage_type                        = var.storage_type
   iam_database_authentication_enabled = var.iam_database_authentication_enabled
-  logs_set                            = compact([
+  logs_set = compact([
     var.enable_audit_log ? "audit" : "",
     var.enable_error_log ? "error" : "",
     var.enable_general_log ? "general" : "",
@@ -148,7 +150,7 @@ locals {
   ])
   enhanced_monitoring_interval = var.enhanced_monitoring_interval
   performance_insights_enabled = var.performance_insights_enabled
-  tags                         = merge({
+  tags = merge({
     Name          = var.name,
     Module        = "RDS MySQL"
     ModuleVersion = "v0.5.0"


### PR DESCRIPTION
Workaround for terraform changes in rds identifier in aws v5.0.0 provider. 

For the details see: https://github.com/hashicorp/terraform-provider-aws/pull/31232.